### PR TITLE
docs: fix all instances of 'interactve' typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ### What is the Solar System activity?
 The Solar System activity is a tool to encourage children
 to learn more about the planets and their moons (natural satellites).
-It is my hope that this tool serves as a practical and interactve
+It is my hope that this tool serves as a practical and interactive
 way to explore astronomy.
 
 ### Learn more about Sugar 

--- a/toolbars.py
+++ b/toolbars.py
@@ -381,7 +381,7 @@ class ToolbarBox(SugarToolbarBox):
         button.add_paragraph(
             _("The Solar System activity is a tool to encourage children\n") +
             _("to learn more about the planets and their moons (natural satellites).\n") +
-            _("It is my hope that this tool serves as a practical and interactve\n") +
+            _("It is my hope that this tool serves as a practical and interactive\n") +
             _("way to explore astronomy.\n")) # flake8: noqa
 
         button.add_section(_("About scales"))


### PR DESCRIPTION
Fixes a typo in the README by correcting “interactve” to “interactive.”
